### PR TITLE
feat(api): Add OpenAPI tags and new game session endpoints

### DIFF
--- a/Backend/src/main/java/c24_71_ft_webapp/nexcognifix/controller/BoardGameController.java
+++ b/Backend/src/main/java/c24_71_ft_webapp/nexcognifix/controller/BoardGameController.java
@@ -5,6 +5,7 @@ import c24_71_ft_webapp.nexcognifix.domain.boardgame.dto.BoardGameDTO;
 import c24_71_ft_webapp.nexcognifix.domain.boardgame.dto.BoardGameFiltersDTO;
 import c24_71_ft_webapp.nexcognifix.domain.gamesession.dto.GameSessionDTO;
 import c24_71_ft_webapp.nexcognifix.domain.gamesession.dto.GameSessionRequestDTO;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -26,6 +27,7 @@ public class BoardGameController {
     private final BoardGameService boardGameService;
 
     @GetMapping
+    @Operation(summary = "Obtener lista de juegos", description = "Devuelve una lista de juegos filtrada por categoría y/o tipo si se proporcionan parámetros.")
     public ResponseEntity<List<BoardGameDTO>> getBoardGames(
             @RequestParam(required = false) String category,
             @RequestParam(required = false) String type) {
@@ -35,6 +37,7 @@ public class BoardGameController {
     }
 
     @GetMapping("/filters")
+    @Operation(summary = "Obtener filtros de juegos", description = "Recupera las categorías y tipos disponibles de juegos.")
     public ResponseEntity<BoardGameFiltersDTO> getGameCategoriesAndTypes() {
         return ResponseEntity.ok(boardGameService.getGameCategoriesAndTypes());
     }

--- a/Backend/src/main/java/c24_71_ft_webapp/nexcognifix/controller/GameSessionController.java
+++ b/Backend/src/main/java/c24_71_ft_webapp/nexcognifix/controller/GameSessionController.java
@@ -3,6 +3,7 @@ package c24_71_ft_webapp.nexcognifix.controller;
 import c24_71_ft_webapp.nexcognifix.domain.gamesession.GameSessionService;
 import c24_71_ft_webapp.nexcognifix.domain.gamesession.dto.GameSessionDTO;
 import c24_71_ft_webapp.nexcognifix.domain.gamesession.dto.GameSessionRequestDTO;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -22,14 +23,13 @@ public class GameSessionController {
 
     private final GameSessionService gameSessionService;
 
-
-    //  Crea una nueva sesión de juego y envía un correo al paciente con los detalles.
+    @Operation(summary = "Crear una nueva sesión de juego", description = "Crea una nueva sesión de juego y envía un correo al paciente con los detalles.")
     @PostMapping("/create")
     public ResponseEntity<GameSessionDTO> createGameSession(@RequestBody @Valid GameSessionRequestDTO data) {
         return ResponseEntity.status(HttpStatus.CREATED).body(gameSessionService.createGameSession(data));
     }
 
-    // Reenviar correo con información de la sesión de juego
+    @Operation(summary = "Reenviar correo de sesión", description = "Reenvía un correo con la información de la sesión de juego.")
     @PostMapping("/{sessionId}/email/resend")
     public ResponseEntity<GameSessionDTO> resendGameSessionEmail(@PathVariable UUID sessionId) {
         GameSessionDTO gameSession = gameSessionService.resendGameSessionEmail(sessionId);
@@ -38,31 +38,45 @@ public class GameSessionController {
 
     /*
 
-    // Obtener una sesión de juego por ID
+    @Operation(summary = "Obtener sesión de juego por ID", description = "Devuelve los detalles de una sesión de juego específica.")
     @GetMapping("/{sessionId}")
     public ResponseEntity<Void> getGameSessionById(@PathVariable UUID sessionId) {
         // TODO: Implementar la obtención de una sesión de juego por ID
         return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).build();
     }
 
-    // Iniciar una sesión de juego
+    @Operation(summary = "Iniciar una sesión de juego", description = "Cambia el estado de la sesión de juego a 'En progreso'.")
     @PatchMapping("/{sessionId}/start")
     public ResponseEntity<Void> startGameSession(@PathVariable UUID sessionId) {
         // TODO: Implementar lógica para marcar la sesión como "En progreso"
         return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).build();
     }
 
-    // Cancelar una sesión de juego
+    @Operation(summary = "Cancelar sesión de juego", description = "Cambia el estado de la sesión de juego a 'Cancelada'.")
     @PatchMapping("/{sessionId}/cancel")
     public ResponseEntity<Void> cancelGameSession(@PathVariable UUID sessionId) {
         // TODO: Implementar lógica para marcar la sesión como "Cancelada"
         return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).build();
     }
 
-    // Enviar resultados de la partida
+    @Operation(summary = "Enviar resultados de la partida", description = "Guarda los resultados de la sesión de juego en la base de datos y los envía al profesional correspondiente.")
     @PostMapping("/{sessionId}/results")
     public ResponseEntity<Void> submitGameResults(@PathVariable UUID sessionId) {
         // TODO: Implementar el almacenamiento de resultados de la partida
+        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).build();
+    }
+
+    @Operation(summary = "Listar las últimas sesiones de juego del profesional autenticado", description = "Obtiene las últimas sesiones de juego creadas por el profesional autenticado.")
+    @GetMapping("/professional/latest")
+    public ResponseEntity<Void> getLatestGameSessionsByAuthenticatedProfessional() {
+        // TODO: Implementar la obtención de las últimas 10 sesiones de juego creadas por el profesional autenticado
+        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).build();
+    }
+
+    @Operation(summary = "Listar todas las partidas de un paciente", description = "Devuelve todas las sesiones de juego asociadas a un paciente específico.")
+    @GetMapping("/patient/{patientId}")
+    public ResponseEntity<Void> getGameSessionsByPatient(@PathVariable UUID patientId) {
+        // TODO: Implementar la obtención de todas las partidas de un paciente
         return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).build();
     }
 


### PR DESCRIPTION
- Added OpenAPI @Tag annotations to BoardGameController and GameSessionController.
- Added base implementations for new endpoints in GameSessionController (functionality not yet implemented):

     -  GET /professional/latest to list the latest game sessions of the authenticated professional.
     -  GET /patient/{patientId} to retrieve all game sessions associated with a specific patient.