### PR TITLE
Corrección de seguridad, ajuste de CORS y adición de endpoints públicos para la sesión de juego

### DIFF
--- a/Backend/src/main/java/c24_71_ft_webapp/nexcognifix/infrastructure/security/PublicEndpoint.java
+++ b/Backend/src/main/java/c24_71_ft_webapp/nexcognifix/infrastructure/security/PublicEndpoint.java
@@ -1,0 +1,9 @@
+package c24_71_ft_webapp.nexcognifix.infrastructure.security;
+
+import org.springframework.http.HttpMethod;
+
+public record PublicEndpoint(
+        String url,
+        HttpMethod method
+) {
+}

--- a/Backend/src/main/java/c24_71_ft_webapp/nexcognifix/infrastructure/security/SecurityConfigurations.java
+++ b/Backend/src/main/java/c24_71_ft_webapp/nexcognifix/infrastructure/security/SecurityConfigurations.java
@@ -34,9 +34,9 @@ public class SecurityConfigurations {
 
     public static final List<PublicEndpoint> PUBLIC_ENDPOINTS = List.of(
             new PublicEndpoint("/api/login", HttpMethod.POST),
-            new PublicEndpoint("/api/game-sessions/{sessionId}", HttpMethod.PATCH),
+            new PublicEndpoint("/api/game-sessions/{sessionId}", HttpMethod.GET),
             new PublicEndpoint("/api/game-sessions/{sessionId}/start", HttpMethod.PATCH),
-            new PublicEndpoint("/api/game-sessions/{sessionId}/cancel", HttpMethod.GET),
+            new PublicEndpoint("/api/game-sessions/{sessionId}/cancel", HttpMethod.PATCH),
             new PublicEndpoint("/api/game-sessions/{sessionId}/results", HttpMethod.POST),
             new PublicEndpoint("/api/docs", HttpMethod.GET),
             new PublicEndpoint("/api/docs/swagger-config", HttpMethod.GET),

--- a/Backend/src/main/java/c24_71_ft_webapp/nexcognifix/infrastructure/security/TokenService.java
+++ b/Backend/src/main/java/c24_71_ft_webapp/nexcognifix/infrastructure/security/TokenService.java
@@ -50,6 +50,7 @@ public class TokenService {
             verifier.getSubject();
         } catch (JWTVerificationException exception) {
             System.out.println(exception.toString());
+            throw exception; // Propaga la excepción para manejo adecuado en el controlador.
         }
         if (verifier == null) {
             throw new RuntimeException("Invalid verifier.");


### PR DESCRIPTION
Implementé una excepción específica para detectar si el token JWT es válido o ha expirado, mejorando así el manejo de errores.

Además, añadí las siguientes rutas a los endpoints públicos para que no requieran autenticación, ya que son utilizadas por el cliente durante la sesión de juego:

- GET /api/game-sessions/{sessionId}
- PATCH /api/game-sessions/{sessionId}/start
- PATCH /api/game-sessions/{sessionId}/cancel
- POST /api/game-sessions/{sessionId}/results

También ajusté la configuración de CORS para permitir las solicitudes necesarias desde el cliente, asegurando que la comunicación entre el frontend y backend funcione correctamente sin restricciones indebidas.