### PR TITLE
Mejoras en configuración, correos y sesiones de juego

### DIFF
--- a/Backend/src/main/java/c24_71_ft_webapp/nexcognifix/domain/boardgame/BoardGame.java
+++ b/Backend/src/main/java/c24_71_ft_webapp/nexcognifix/domain/boardgame/BoardGame.java
@@ -48,6 +48,9 @@ public class BoardGame {
     @Column(name = "status", nullable = false)
     private Boolean status = true;
 
+    @Column(name = "image_url", nullable = false)
+    private String imageUrl;
+
     @Column(name = "created_at", updatable = false)
     @CreationTimestamp
     private LocalDateTime createdAt;

--- a/Backend/src/main/java/c24_71_ft_webapp/nexcognifix/domain/boardgame/BoardGameService.java
+++ b/Backend/src/main/java/c24_71_ft_webapp/nexcognifix/domain/boardgame/BoardGameService.java
@@ -53,7 +53,8 @@ public class BoardGameService {
                 boardGame.getRules(),
                 boardGame.getCategory(),
                 boardGame.getType(),
-                boardGame.getStatus()
+                boardGame.getStatus(),
+                boardGame.getImageUrl()
         );
     }
 }

--- a/Backend/src/main/java/c24_71_ft_webapp/nexcognifix/domain/boardgame/dto/BoardGameDTO.java
+++ b/Backend/src/main/java/c24_71_ft_webapp/nexcognifix/domain/boardgame/dto/BoardGameDTO.java
@@ -13,5 +13,6 @@ public record BoardGameDTO(
         String rules,
         GameCategory category,
         GameType type,
-        Boolean status
+        Boolean status,
+        String imageUrl
 ) { }

--- a/Backend/src/main/java/c24_71_ft_webapp/nexcognifix/domain/gamesession/GameSession.java
+++ b/Backend/src/main/java/c24_71_ft_webapp/nexcognifix/domain/gamesession/GameSession.java
@@ -106,7 +106,10 @@ public class GameSession {
     // Cancela la sesión de juego, estableciendo el estado en CANCELED.
     public void cancelSession(String observation) {
         if (this.status == GameStatus.COMPLETED) {
-            throw new AppException("No puedes cancelar una sesión que ya ha finalizado.", "BAD_REQUEST");
+            throw new AppException("No es posible cancelar una sesión que ya ha finalizado.", "CONFLICT");
+        }
+        if (this.status == GameStatus.CANCELED) {
+            throw new AppException("No es posible cancelar una sesión que ya está cancelada.", "CONFLICT");
         }
         this.status = GameStatus.CANCELED;
         this.observation = observation;

--- a/Backend/src/main/java/c24_71_ft_webapp/nexcognifix/domain/gamesession/GameSessionService.java
+++ b/Backend/src/main/java/c24_71_ft_webapp/nexcognifix/domain/gamesession/GameSessionService.java
@@ -10,6 +10,7 @@ import c24_71_ft_webapp.nexcognifix.domain.patient.PatientRepository;
 import c24_71_ft_webapp.nexcognifix.domain.professional.Professional;
 import c24_71_ft_webapp.nexcognifix.infrastructure.email.EmailService;
 import c24_71_ft_webapp.nexcognifix.infrastructure.exception.AppException;
+import c24_71_ft_webapp.nexcognifix.infrastructure.security.AuthService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -24,6 +25,7 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class GameSessionService {
 
+    private final AuthService authService;
     private final BoardGameRepository boardGameRepository;
     private final GameSessionRepository gameSessionRepository;
     private final PatientRepository patientRepository;
@@ -157,17 +159,9 @@ public class GameSessionService {
         );
     }
 
-
-    // TODO: Esta función debería trasladarse a un servicio común o helper,
-    // ya que se usa en diferentes servicios. Se encuentra aquí provisionalmente.
+    // Obtiene el profesional autenticado
     public Professional getAuthenticatedUser() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-
-        if (authentication.getPrincipal() instanceof Professional) {
-            return (Professional) authentication.getPrincipal();
-        }
-
-        throw new AppException("El usuario autenticado no es válido.", "FORBIDDEN");
+        return authService.getAuthenticatedUser();
     }
 
     public Page<GameSessionDTO> getAllGameSessionsByPatient(UUID patientId, Pageable pageable) {

--- a/Backend/src/main/java/c24_71_ft_webapp/nexcognifix/domain/gamesession/dto/GameSessionRequestDTO.java
+++ b/Backend/src/main/java/c24_71_ft_webapp/nexcognifix/domain/gamesession/dto/GameSessionRequestDTO.java
@@ -21,7 +21,7 @@ public record GameSessionRequestDTO(
 
         @NotNull(message = "El número de fichas de juego no puede ser nulo.")
         @Min(value = 10, message = "El número de fichas de juego debe ser al menos 10.")
-        @Max(value = 100, message = "El número de fichas de juego no puede superar 100.")
+        @Max(value = 50, message = "El número de fichas de juego no puede superar 50.")
         @EvenNumber(message = "El número de fichas de juego debe ser par.")
         Integer game_chips,
 

--- a/Backend/src/main/java/c24_71_ft_webapp/nexcognifix/infrastructure/email/EmailService.java
+++ b/Backend/src/main/java/c24_71_ft_webapp/nexcognifix/infrastructure/email/EmailService.java
@@ -28,7 +28,7 @@ public class EmailService {
 
     private final JavaMailSender mailSender;
 
-    @Value("${frontend.url:http://localhost:5173}")
+    @Value("${frontend.redirect.url}")
     private String frontendUrl;
 
     @Value("${spring.mail.username}")
@@ -37,7 +37,7 @@ public class EmailService {
 
     // Envía un correo de sesión de juego.
     public void sendGameSessionEmail(GameSession gameSession) {
-        String gameSessionUrl = frontendUrl + "/game-session/" + gameSession.getIdSession();
+        String gameSessionUrl = frontendUrl + "/game-sessions/patient/join/" + gameSession.getIdSession();
 
         // Convertir reglas en una lista HTML
         String gameRulesList = convertRulesToHtmlList(gameSession.getBoardGame().getRules());
@@ -59,7 +59,7 @@ public class EmailService {
     // Envía un correo con el resultado de un juego.
     public void sendGameResultEmail(GameSession gameSession) {
 
-        String gameSessionUrl = frontendUrl + "/game-result/" + gameSession.getIdSession();
+        String gameSessionUrl = frontendUrl + "/dashboard/patients";
 
         String emailContent = loadTemplate("game_result_email.html")
                 .replace("{RESULTS_URL}", gameSessionUrl)

--- a/Backend/src/main/java/c24_71_ft_webapp/nexcognifix/infrastructure/security/SecurityConfigurations.java
+++ b/Backend/src/main/java/c24_71_ft_webapp/nexcognifix/infrastructure/security/SecurityConfigurations.java
@@ -26,8 +26,8 @@ import java.util.List;
 @Configuration
 public class SecurityConfigurations {
 
-    @Value("${frontend.url:http://localhost:5173}")
-    private String frontendUrl;
+    @Value("${frontend.cors.url}")
+    private String frontendCors;
 
     @Autowired
     private SecurityFilter securityFilter;
@@ -84,7 +84,7 @@ public class SecurityConfigurations {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOriginPatterns(Collections.singletonList(frontendUrl));
+        configuration.setAllowedOriginPatterns(Collections.singletonList(frontendCors));
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
         configuration.setAllowedHeaders(Arrays.asList("Authorization", "Content-Type"));
         configuration.setAllowCredentials(true);

--- a/Backend/src/main/resources/application.properties
+++ b/Backend/src/main/resources/application.properties
@@ -24,7 +24,8 @@ spring.flyway.baseline-on-migrate=true
 spring.flyway.locations=classpath:db/migrations
 
 # Frontend configuration
-frontend.url=${FRONTEND_URL:http://localhost:5173}
+frontend.cors.url=${FRONTEND_CORS_URL:*}
+frontend.redirect.url=${FRONTEND_REDIRECT_URL:http://localhost:5173}
 
 # Email configuration
 spring.mail.host=${EMAIL_HOST:smtp.example.com}


### PR DESCRIPTION
- Se separaron las URLs del frontend para CORS y redirección en correos.
- Se actualizaron las URLs de las sesiones de juego en las plantillas de correo electrónico.
- Se corrigió un error que permitía cancelar una sesión de juego ya cancelada.
- Se refactorizó la obtención del usuario autenticado utilizando AuthService.
- Se redujo el número máximo de fichas de juego de 100 a 50.
- Se agregó el campo imageUrl al modelo, servicio y DTO de boardgame.